### PR TITLE
Feat: adds windowed rank order reducer

### DIFF
--- a/src/xarray_multiscale/__init__.py
+++ b/src/xarray_multiscale/__init__.py
@@ -5,4 +5,5 @@ from .reducers import (  # noqa: F401
     windowed_mode,
     windowed_max,
     windowed_min,
+    windowed_rank,
 )

--- a/tests/test_reducers.py
+++ b/tests/test_reducers.py
@@ -10,6 +10,7 @@ from xarray_multiscale.reducers import (
     windowed_mean,
     windowed_min,
     windowed_mode,
+    windowed_rank,
 )
 
 
@@ -60,6 +61,38 @@ def test_windowed_mode():
     answer = np.array([[1, 0], [0, 2]])
     results = windowed_mode(data, (2, 2))
     assert np.array_equal(results, answer)
+
+
+def test_windowed_rank():
+    initial_array = np.array([[[1, 2],
+                               [3, 4]],
+                              [[5, 6],
+                               [7, 8]]])
+    larger_array = np.tile(initial_array, (2, 2, 2))
+    window_size = (2, 2, 2)
+
+    # 2nd brightest voxel
+    rank = np.product(window_size) - 2
+    answer = np.array([[[7, 7],
+                        [7, 7]],
+                       [[7, 7],
+                        [7, 7]]])
+    results = windowed_rank(larger_array, window_size, rank)
+    assert np.array_equal(results, answer)
+
+    # Test negative rank
+    rank = -8
+    answer = np.array([[[1, 1],
+                        [1, 1]],
+                       [[1, 1],
+                        [1, 1]]])
+    results = windowed_rank(larger_array, window_size, rank)
+    assert np.array_equal(results, answer)
+
+    # Test out-of-bounds rank
+    rank = 100
+    with pytest.raises(ValueError):
+        windowed_rank(larger_array, window_size, rank)
 
 
 @pytest.mark.parametrize("windows_per_dim", (1, 2, 3, 4, 5))


### PR DESCRIPTION
Hello,

First, thanks for creating this package! We use it in several parts of our data pipeline for ExASPIM samples.
One thing that we observed is that, since our foreground signal is sparse (fluorescently labelled neurites), using the `windowed_mean` reducer can slightly dilute the signal with progressive downscaling. Using the `windowed_max` counteracts this, but also introduces more noise. For a previous project, we had used the 2nd brightest voxel instead of the max, which was better able to preserve SNR and overall dynamic range at higher scales. This PR provides an implementation of a general windowed rank filter, which can be used to pick an index from a sorted window.

Here is an example comparing the `windowed_mean` , `windowed_max` and `windowed_rank`, toggle the layers individually to see the difference [neuroglancer link](https://neuroglancer-demo.appspot.com/#!%7B%22dimensions%22:%7B%22x%22:%5B7.48e-7%2C%22m%22%5D%2C%22y%22:%5B7.48e-7%2C%22m%22%5D%2C%22z%22:%5B0.000001%2C%22m%22%5D%2C%22t%22:%5B0.001%2C%22s%22%5D%7D%2C%22position%22:%5B4687.7578125%2C1732.3731689453125%2C1864%2C0%5D%2C%22crossSectionScale%22:4.481689070338065%2C%22projectionScale%22:8192%2C%22layers%22:%5B%7B%22type%22:%22image%22%2C%22source%22:%22zarr://s3://aind-open-data/exaSPIM_685222_2024-05-07_13-51-39_fusion_2024-07-09_23-08-02/fused.zarr/%22%2C%22localDimensions%22:%7B%22c%27%22:%5B1%2C%22%22%5D%7D%2C%22localPosition%22:%5B0%5D%2C%22tab%22:%22rendering%22%2C%22opacity%22:1%2C%22shaderControls%22:%7B%22normalized%22:%7B%22range%22:%5B0%2C16323%5D%7D%7D%2C%22name%22:%22fused.zarr%22%7D%2C%7B%22type%22:%22image%22%2C%22source%22:%22zarr://s3://aind-open-data/exaSPIM_685222_2024-05-07_13-51-39_fusion_2024-07-09_23-08-02/fused_2nd_brightest.zarr/%22%2C%22localDimensions%22:%7B%22c%27%22:%5B1%2C%22%22%5D%7D%2C%22localPosition%22:%5B0%5D%2C%22tab%22:%22rendering%22%2C%22opacity%22:1%2C%22shaderControls%22:%7B%22normalized%22:%7B%22range%22:%5B0%2C16323%5D%7D%7D%2C%22name%22:%22fused_2nd_brightest.zarr%22%2C%22visible%22:false%7D%2C%7B%22type%22:%22image%22%2C%22source%22:%22zarr://s3://aind-open-data/exaSPIM_685222_2024-05-07_13-51-39_fusion_2024-07-09_23-08-02/fused_max_downsampled.zarr%22%2C%22localDimensions%22:%7B%22c%27%22:%5B1%2C%22%22%5D%7D%2C%22localPosition%22:%5B0%5D%2C%22tab%22:%22rendering%22%2C%22opacity%22:1%2C%22shaderControls%22:%7B%22normalized%22:%7B%22range%22:%5B0%2C16323%5D%7D%7D%2C%22name%22:%22fused_max_downsampled.zarr%22%2C%22visible%22:false%7D%5D%2C%22selectedLayer%22:%7B%22visible%22:true%2C%22layer%22:%22fused.zarr%22%7D%2C%22layout%22:%224panel%22%7D)

To test performance, I compared runtimes for `windowed_mean` and `windowed_rank` for a 1024**3 array. They are comparable for `uint16` arrays and slower for `float32`.

```python
import time

import numpy as np
import pytest

from xarray_multiscale.reducers import windowed_rank, windowed_mean


@pytest.mark.parametrize('dtype', (np.float32, np.uint16))
def test_rank_performance(dtype: np.dtype):
    data = np.array([[[1, 2],
                      [3, 4]],
                     [[5, 6],
                      [7, 8]]])
    larger_array = np.tile(data, (512, 512, 512)).astype(dtype)
    window_size = (2, 2, 2)

    t0 = time.time()
    result = windowed_rank(larger_array, window_size, -1)
    print(time.time() - t0) 

    t0 = time.time()
    result = windowed_mean(larger_array, window_size)
    print(time.time() - t0)  
```

```
============================= 2 passed in 49.59s ==============================
PASSED                      [ 50%]16.414945602416992
8.375742673873901
PASSED                       [100%]7.440253496170044
8.397003173828125
```

One issue with my implementation is that it has a required positional argument that is not in the `Protocol` signature, `rank: int`. The way I am hacking around this now is to use partial objects, e.g., 

```python
from functools import partial
from xarray_multiscale import multiscale, windowed_rank

arr = ...
reducer = partial(windowed_rank, rank=-2)
multiscale(arr, reducer, (2,2))
``` 

I see that there is  `**kwargs` support for the reducers, but I wasn't sure if that was the best approach since it is a required argument. Let me know what you think!

Thanks,
Cameron
